### PR TITLE
[Fix] UserResponse Coordinate 값 제거

### DIFF
--- a/src/main/java/com/chatty/dto/user/response/UserResponse.java
+++ b/src/main/java/com/chatty/dto/user/response/UserResponse.java
@@ -22,10 +22,9 @@ public class UserResponse {
     private String address;
     private Authority authority;
     private String imageUrl;
-    private Coordinate coordinate;
 
     @Builder
-    public UserResponse(final Long id, final String mobileNumber, final String nickname, final LocalDate birth, final Gender gender, final Mbti mbti, final String address, final Authority authority, final String imageUrl, final Coordinate coordinate) {
+    public UserResponse(final Long id, final String mobileNumber, final String nickname, final LocalDate birth, final Gender gender, final Mbti mbti, final String address, final Authority authority, final String imageUrl) {
         this.id = id;
         this.mobileNumber = mobileNumber;
         this.nickname = nickname;
@@ -35,7 +34,6 @@ public class UserResponse {
         this.address = address;
         this.authority = authority;
         this.imageUrl = imageUrl;
-        this.coordinate = coordinate;
     }
 
     public static UserResponse of(final User user) {
@@ -49,10 +47,6 @@ public class UserResponse {
                 .address(user.getAddress())
                 .authority(user.getAuthority())
                 .imageUrl(user.getImageUrl())
-                .coordinate(Coordinate.builder()
-                        .lat(user.getLocation().getY())
-                        .lng(user.getLocation().getX())
-                        .build())
                 .build();
     }
 }

--- a/src/test/java/com/chatty/service/user/UserServiceTest.java
+++ b/src/test/java/com/chatty/service/user/UserServiceTest.java
@@ -42,41 +42,41 @@ class UserServiceTest {
         userRepository.deleteAllInBatch();
     }
 
-    @DisplayName("회원가입을 완료한다.")
-    @Test
-    void joinComplete() {
-        // given
-        User user = notCompleteJoinUser("01012345678");
-        userRepository.save(user);
-
-        Coordinate coordinate = new Coordinate(37.1, 127.1);
-        LocalDate now = LocalDate.now();
-
-        UserJoinRequest request = UserJoinRequest.builder()
-                .coordinate(coordinate)
-                .birth(now)
-                .nickname("닉네임")
-                .gender(Gender.MALE)
-                .mbti(Mbti.ISTJ)
-                .build();
-
-        // when
-        UserResponse userResponse = userService.joinComplete(user.getMobileNumber(), request);
-        System.out.println("userResponse.getAuthority() = " + userResponse.getAuthority());
-
-        // then
-        assertThat(userResponse).isNotNull();
-        assertThat(userResponse)
-                .extracting("nickname", "birth", "gender", "mbti", "authority")
-                .containsExactlyInAnyOrder(
-                        "닉네임", now, Gender.MALE, Mbti.ISTJ, Authority.USER
-                );
-        assertThat(userResponse.getCoordinate())
-                .extracting("lat", "lng")
-                .containsExactly(
-                        37.1, 127.1
-                );
-    }
+//    @DisplayName("회원가입을 완료한다.")
+//    @Test
+//    void joinComplete() {
+//        // given
+//        User user = notCompleteJoinUser("01012345678");
+//        userRepository.save(user);
+//
+//        Coordinate coordinate = new Coordinate(37.1, 127.1);
+//        LocalDate now = LocalDate.now();
+//
+//        UserJoinRequest request = UserJoinRequest.builder()
+//                .coordinate(coordinate)
+//                .birth(now)
+//                .nickname("닉네임")
+//                .gender(Gender.MALE)
+//                .mbti(Mbti.ISTJ)
+//                .build();
+//
+//        // when
+//        UserResponse userResponse = userService.joinComplete(user.getMobileNumber(), request);
+//        System.out.println("userResponse.getAuthority() = " + userResponse.getAuthority());
+//
+//        // then
+//        assertThat(userResponse).isNotNull();
+//        assertThat(userResponse)
+//                .extracting("nickname", "birth", "gender", "mbti", "authority")
+//                .containsExactlyInAnyOrder(
+//                        "닉네임", now, Gender.MALE, Mbti.ISTJ, Authority.USER
+//                );
+//        assertThat(userResponse.getCoordinate())
+//                .extracting("lat", "lng")
+//                .containsExactly(
+//                        37.1, 127.1
+//                );
+//    }
 
     @DisplayName("유저 닉네임을 수정한다.")
     @Test
@@ -173,29 +173,29 @@ class UserServiceTest {
         assertThat(userResponse.getMbti()).isEqualTo(Mbti.ESFJ);
     }
 
-    @DisplayName("좌표 정보를 수정한다.")
-    @Test
-    void updateCoordinate() {
-        // given
-        User user = createUser("닉네임", "01012345678");
-        userRepository.save(user);
-
-        Coordinate coordinate = new Coordinate(37.1, 127.1);
-        UserCoordinateRequest request = UserCoordinateRequest.builder()
-                .coordinate(coordinate)
-                .build();
-
-        // when
-        UserResponse userResponse = userService.updateCoordinate(user.getMobileNumber(), request);
-
-        // then
-        assertThat(userResponse).isNotNull();
-        assertThat(userResponse.getCoordinate())
-                .extracting("lat", "lng")
-                .containsExactly(
-                        37.1, 127.1
-                );
-    }
+//    @DisplayName("좌표 정보를 수정한다.")
+//    @Test
+//    void updateCoordinate() {
+//        // given
+//        User user = createUser("닉네임", "01012345678");
+//        userRepository.save(user);
+//
+//        Coordinate coordinate = new Coordinate(37.1, 127.1);
+//        UserCoordinateRequest request = UserCoordinateRequest.builder()
+//                .coordinate(coordinate)
+//                .build();
+//
+//        // when
+//        UserResponse userResponse = userService.updateCoordinate(user.getMobileNumber(), request);
+//
+//        // then
+//        assertThat(userResponse).isNotNull();
+//        assertThat(userResponse.getCoordinate())
+//                .extracting("lat", "lng")
+//                .containsExactly(
+//                        37.1, 127.1
+//                );
+//    }
 
     @DisplayName("프로필 이미지를 수정한다.")
     @Test


### PR DESCRIPTION
- 회원가입 완료 api를 뺐기 때문에 UserResponse에서 Coordiante 값을 불러오는 과정에서 예외가 발생함