### PR TITLE
[Feat] 티켓, 캔디 컬럼 추가 및 프로필 잠금 해제 로직에 적용

### DIFF
--- a/src/main/java/com/chatty/constants/Code.java
+++ b/src/main/java/com/chatty/constants/Code.java
@@ -33,6 +33,7 @@ public enum Code {
     NOT_EXIST_INTEREST(HttpStatus.BAD_REQUEST, "존재하지 않는 관심사입니다.", "E024"),
     ALREADY_UNLOCK_PROFILE(HttpStatus.CONFLICT, "이미 프로필 잠금을 해제했습니다.", "E025"),
     INSUFFICIENT_CANDY(HttpStatus.BAD_REQUEST, "캔디의 개수가 부족합니다.", "E026"),
+    INSUFFICIENT_TICKET(HttpStatus.BAD_REQUEST, "티켓의 개수가 부족합니다.", "E027"),
 
 
     // ratelimit

--- a/src/main/java/com/chatty/constants/Code.java
+++ b/src/main/java/com/chatty/constants/Code.java
@@ -31,6 +31,9 @@ public enum Code {
     NOT_BLUECHECK_USER(HttpStatus.UNAUTHORIZED, "프로필 인증이 되어있지 않습니다.", "E022"),
     INVALID_DEVICE_NUMER(HttpStatus.BAD_REQUEST, "기존 계정과 기기 번호가 일치하지 않습니다.","E023"),
     NOT_EXIST_INTEREST(HttpStatus.BAD_REQUEST, "존재하지 않는 관심사입니다.", "E024"),
+    ALREADY_UNLOCK_PROFILE(HttpStatus.CONFLICT, "이미 프로필 잠금을 해제했습니다.", "E025"),
+    INSUFFICIENT_CANDY(HttpStatus.BAD_REQUEST, "캔디의 개수가 부족합니다.", "E026"),
+
 
     // ratelimit
     TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "너무 많은 요청을 보냈습니다.","E098");

--- a/src/main/java/com/chatty/controller/profile/ProfileUnlockController.java
+++ b/src/main/java/com/chatty/controller/profile/ProfileUnlockController.java
@@ -5,6 +5,7 @@ import com.chatty.dto.profileUnlock.request.ProfileUnlockRequest;
 import com.chatty.dto.profileUnlock.response.ProfileUnlockResponse;
 import com.chatty.dto.user.response.UserProfileResponse;
 import com.chatty.service.profileUnlock.ProfileUnlockService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,12 +22,14 @@ public class ProfileUnlockController {
 
     private final ProfileUnlockService profileUnlockService;
 
+    @Operation(summary = "프로필 잠금 해제", description = "상대방 프로필 잠금을 해제합니다.")
     @PostMapping("/profile/{userId}")
     public ApiResponse<ProfileUnlockResponse> unlockProfile(@PathVariable final Long userId, Authentication authentication,
                                                              @Valid @RequestBody final ProfileUnlockRequest request) {
         return ApiResponse.ok(profileUnlockService.unlockProfile(userId, authentication.getName(), request, LocalDateTime.now()));
     }
 
+    @Operation(summary = "상대방 프로필 조회", description = "상대방 프로필을 조회합니다. 잠금을 해제하였으면 true, 아니면 false")
     @GetMapping("/profile/{userId}")
     public ApiResponse<UserProfileResponse> getUserProfile(@PathVariable final Long userId, Authentication authentication) {
         return ApiResponse.ok(profileUnlockService.getUserProfile(userId, authentication.getName()));

--- a/src/main/java/com/chatty/controller/profile/ProfileUnlockController.java
+++ b/src/main/java/com/chatty/controller/profile/ProfileUnlockController.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -22,7 +24,7 @@ public class ProfileUnlockController {
     @PostMapping("/profile/{userId}")
     public ApiResponse<ProfileUnlockResponse> unlockProfile(@PathVariable final Long userId, Authentication authentication,
                                                              @Valid @RequestBody final ProfileUnlockRequest request) {
-        return ApiResponse.ok(profileUnlockService.unlockProfile(userId, authentication.getName(), request));
+        return ApiResponse.ok(profileUnlockService.unlockProfile(userId, authentication.getName(), request, LocalDateTime.now()));
     }
 
     @GetMapping("/profile/{userId}")

--- a/src/main/java/com/chatty/dto/profileUnlock/request/ProfileUnlockRequest.java
+++ b/src/main/java/com/chatty/dto/profileUnlock/request/ProfileUnlockRequest.java
@@ -3,6 +3,8 @@ package com.chatty.dto.profileUnlock.request;
 import com.chatty.entity.user.ProfileUnlock;
 import com.chatty.entity.user.User;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,12 +16,14 @@ import java.time.LocalDateTime;
 @Getter
 public class ProfileUnlockRequest {
 
-    @AssertTrue(message = "true 값만 들어올 수 있습니다.")
-    private Boolean unlock;
+//    @AssertTrue(message = "true 값만 들어올 수 있습니다.")
+//    private Boolean unlock;
+    @NotBlank(message = "candy또는 ticket을 입력해주세요.")
+    private String unlockMethod;
 
     @Builder
-    public ProfileUnlockRequest(final Boolean unlock) {
-        this.unlock = unlock;
+    public ProfileUnlockRequest(final String unlockMethod) {
+        this.unlockMethod = unlockMethod;
     }
 
     public ProfileUnlock toEntity(final User unlocker, final User unlockedUser, LocalDateTime localDateTime) {

--- a/src/main/java/com/chatty/dto/profileUnlock/request/ProfileUnlockRequest.java
+++ b/src/main/java/com/chatty/dto/profileUnlock/request/ProfileUnlockRequest.java
@@ -26,11 +26,11 @@ public class ProfileUnlockRequest {
         this.unlockMethod = unlockMethod;
     }
 
-    public ProfileUnlock toEntity(final User unlocker, final User unlockedUser, LocalDateTime localDateTime) {
+    public ProfileUnlock toEntity(final User unlocker, final User unlockedUser, LocalDateTime registeredDateTime) {
         return ProfileUnlock.builder()
                 .unlocker(unlocker)
                 .unlockedUser(unlockedUser)
-                .localDateTime(localDateTime)
+                .registeredDateTime(registeredDateTime)
                 .build();
     }
 

--- a/src/main/java/com/chatty/dto/profileUnlock/response/ProfileUnlockResponse.java
+++ b/src/main/java/com/chatty/dto/profileUnlock/response/ProfileUnlockResponse.java
@@ -15,14 +15,14 @@ public class ProfileUnlockResponse {
     private Long id;
     private Long unlockerId;
     private Long unlockedUserId;
-    private LocalDateTime localDateTime;
+    private LocalDateTime registeredDateTime;
 
     @Builder
-    public ProfileUnlockResponse(final Long id, final Long unlockerId, final Long unlockedUserId, final LocalDateTime localDateTime) {
+    public ProfileUnlockResponse(final Long id, final Long unlockerId, final Long unlockedUserId, final LocalDateTime registeredDateTime) {
         this.id = id;
         this.unlockerId = unlockerId;
         this.unlockedUserId = unlockedUserId;
-        this.localDateTime = localDateTime;
+        this.registeredDateTime = registeredDateTime;
     }
 
     public static ProfileUnlockResponse of(final ProfileUnlock profileUnlock) {
@@ -30,7 +30,7 @@ public class ProfileUnlockResponse {
                 .id(profileUnlock.getId())
                 .unlockerId(profileUnlock.getUnlocker().getId())
                 .unlockedUserId(profileUnlock.getUnlockedUser().getId())
-                .localDateTime(profileUnlock.getLocalDateTime())
+                .registeredDateTime(profileUnlock.getRegisteredDateTime())
                 .build();
     }
 }

--- a/src/main/java/com/chatty/entity/user/ProfileUnlock.java
+++ b/src/main/java/com/chatty/entity/user/ProfileUnlock.java
@@ -25,12 +25,12 @@ public class ProfileUnlock {
     @JoinColumn(name = "unlocked_user_id")
     private User unlockedUser;
 
-    private LocalDateTime localDateTime;
+    private LocalDateTime registeredDateTime;
 
     @Builder
-    public ProfileUnlock(final User unlocker, final User unlockedUser, final LocalDateTime localDateTime) {
+    public ProfileUnlock(final User unlocker, final User unlockedUser, final LocalDateTime registeredDateTime) {
         this.unlocker = unlocker;
         this.unlockedUser = unlockedUser;
-        this.localDateTime = localDateTime;
+        this.registeredDateTime = registeredDateTime;
     }
 }

--- a/src/main/java/com/chatty/entity/user/User.java
+++ b/src/main/java/com/chatty/entity/user/User.java
@@ -79,6 +79,9 @@ public class User extends CommonEntity implements UserDetails{
 
     private boolean blueCheck;
 
+    private int ticket;
+    private int candy;
+
     public void joinComplete(final User request) {
         this.nickname = request.getNickname();
         this.location = request.getLocation();
@@ -94,6 +97,7 @@ public class User extends CommonEntity implements UserDetails{
 
     public void updateGender(final Gender gender) {
         this.gender = gender;
+        this.ticket = gender.getGender().equals("남") ? 5 : 11;
     }
 
     public void updateBirth(final LocalDate birth) {

--- a/src/main/java/com/chatty/entity/user/User.java
+++ b/src/main/java/com/chatty/entity/user/User.java
@@ -1,8 +1,10 @@
 package com.chatty.entity.user;
 
 import com.chatty.constants.Authority;
+import com.chatty.constants.Code;
 import com.chatty.entity.CommonEntity;
 import com.chatty.entity.check.AuthCheck;
+import com.chatty.exception.CustomException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
@@ -143,6 +145,18 @@ public class User extends CommonEntity implements UserDetails{
 
     public void updateIntroduce(final String introduce) {
         this.introduce = introduce;
+    }
+
+    public boolean isCandyQuantityLessThan(final int candy) {
+        return this.candy < candy;
+    }
+
+    public void deductCandyQuantity(final int candy) {
+        if (isCandyQuantityLessThan(candy)) {
+            throw new CustomException(Code.INSUFFICIENT_CANDY);
+        }
+
+        this.candy -= candy;
     }
 
     @Override

--- a/src/main/java/com/chatty/entity/user/User.java
+++ b/src/main/java/com/chatty/entity/user/User.java
@@ -159,6 +159,18 @@ public class User extends CommonEntity implements UserDetails{
         this.candy -= candy;
     }
 
+    public boolean isTicketQuantityLessThan(final int ticket) {
+        return this.ticket < ticket;
+    }
+
+    public void deductTicketQuantity(final int ticket) {
+        if (isTicketQuantityLessThan(ticket)) {
+            throw new CustomException(Code.INSUFFICIENT_TICKET);
+        }
+
+        this.ticket -= ticket;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_" + authority.name()));

--- a/src/main/java/com/chatty/service/profileUnlock/ProfileUnlockService.java
+++ b/src/main/java/com/chatty/service/profileUnlock/ProfileUnlockService.java
@@ -43,6 +43,12 @@ public class ProfileUnlockService {
             }
 
             unlocker.deductCandyQuantity(7);
+        } else if (unlockMethod.equals("ticket")) {
+            if (unlocker.isTicketQuantityLessThan(1)) {
+                throw new CustomException(Code.INSUFFICIENT_TICKET);
+            }
+
+            unlocker.deductTicketQuantity(1);
         }
 
         ProfileUnlock profileUnlock = request.toEntity(unlocker, unlockedUser, now);

--- a/src/test/java/com/chatty/controller/profile/ProfileUnlockControllerTest.java
+++ b/src/test/java/com/chatty/controller/profile/ProfileUnlockControllerTest.java
@@ -63,22 +63,22 @@ class ProfileUnlockControllerTest {
                 .andExpect(status().isOk());
     }
 
-//    @DisplayName("상대방 프로필 잠금을 해제할 때, true값을 입력해야 된다.")
-//    @Test
-//    void unlockProfileWithFalse() throws Exception {
-//        // given
-//        ProfileUnlockRequest request = ProfileUnlockRequest.builder()
+    @DisplayName("상대방 프로필 잠금을 해제할 때, candy or ticket을 입력해야 합니다.")
+    @Test
+    void unlockProfileWithFalse() throws Exception {
+        // given
+        ProfileUnlockRequest request = ProfileUnlockRequest.builder()
 //                .unlock(false)
-//                .build();
-//
-//        // when // then
-//        mockMvc.perform(
-//                        post("/api/v1/users/profile/{userId}", 2L).with(csrf())
-//                                .contentType(MediaType.APPLICATION_JSON)
-//                                .content(objectMapper.writeValueAsString(request))
-//                )
-//                .andDo(print())
-//                .andExpect(status().isBadRequest())
-//                .andExpect(jsonPath("$.message").value("true 값만 들어올 수 있습니다."));
-//    }
+                .build();
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/users/profile/{userId}", 2L).with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("candy또는 ticket을 입력해주세요."));
+    }
 }

--- a/src/test/java/com/chatty/controller/profile/ProfileUnlockControllerTest.java
+++ b/src/test/java/com/chatty/controller/profile/ProfileUnlockControllerTest.java
@@ -50,7 +50,7 @@ class ProfileUnlockControllerTest {
     void unlockProfile() throws Exception {
         // given
         ProfileUnlockRequest request = ProfileUnlockRequest.builder()
-                .unlock(true)
+                .unlockMethod("candy")
                 .build();
 
         // when // then
@@ -63,22 +63,22 @@ class ProfileUnlockControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("상대방 프로필 잠금을 해제할 때, true값을 입력해야 된다.")
-    @Test
-    void unlockProfileWithFalse() throws Exception {
-        // given
-        ProfileUnlockRequest request = ProfileUnlockRequest.builder()
-                .unlock(false)
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        post("/api/v1/users/profile/{userId}", 2L).with(csrf())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("true 값만 들어올 수 있습니다."));
-    }
+//    @DisplayName("상대방 프로필 잠금을 해제할 때, true값을 입력해야 된다.")
+//    @Test
+//    void unlockProfileWithFalse() throws Exception {
+//        // given
+//        ProfileUnlockRequest request = ProfileUnlockRequest.builder()
+//                .unlock(false)
+//                .build();
+//
+//        // when // then
+//        mockMvc.perform(
+//                        post("/api/v1/users/profile/{userId}", 2L).with(csrf())
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(objectMapper.writeValueAsString(request))
+//                )
+//                .andDo(print())
+//                .andExpect(status().isBadRequest())
+//                .andExpect(jsonPath("$.message").value("true 값만 들어올 수 있습니다."));
+//    }
 }

--- a/src/test/java/com/chatty/entity/user/UserTest.java
+++ b/src/test/java/com/chatty/entity/user/UserTest.java
@@ -25,7 +25,7 @@ class UserTest {
     @Test
     void isCandyQuantityLessThan() {
         // given
-        User user = createUser(6);
+        User user = createUser(6, 5);
 
         // when
         boolean result = user.isCandyQuantityLessThan(7);
@@ -38,7 +38,7 @@ class UserTest {
     @Test
     void deductCandyQuantity() {
         // given
-        User user = createUser(7);
+        User user = createUser(7, 5);
         int candy = 7;
 
         // when
@@ -52,7 +52,7 @@ class UserTest {
     @Test
     void deductCandyQuantity2() {
         // given
-        User user = createUser(6);
+        User user = createUser(6, 5);
         int candy = 7;
 
         // when // then
@@ -61,16 +61,57 @@ class UserTest {
                 .hasMessage("캔디의 개수가 부족합니다.");
     }
 
+    @DisplayName("내가 보유하고있는 티켓의 수량이 필요한 티켓의 수량보다 작은지 확인한다.")
+    @Test
+    void isTicketQuantityLessThan() {
+        // given
+        User user = createUser(6, 0);
+
+        // when
+        boolean result = user.isTicketQuantityLessThan(1);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("내가 보유하고있는 티켓의 수량을 차감한다.")
+    @Test
+    void deductTicketQuantity() {
+        // given
+        User user = createUser(7, 1);
+        int ticket = 1;
+
+        // when
+        user.deductTicketQuantity(ticket);
+
+        // then
+        assertThat(user.getTicket()).isZero();
+    }
+
+    @DisplayName("내가 보유하고있는 티켓의 수량이 부족하면 예외가 발생한다.")
+    @Test
+    void deductTicketQuantity2() {
+        // given
+        User user = createUser(6, 0);
+        int ticket = 1;
+
+        // when // then
+        assertThatThrownBy(() -> user.deductTicketQuantity(ticket))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("티켓의 개수가 부족합니다.");
+    }
+
     private User createUser() {
         return User.builder()
                 .nickname("닉네임")
                 .build();
     }
 
-    private User createUser(final int candy) {
+    private User createUser(final int candy, final int ticket) {
         return User.builder()
                 .nickname("닉네임")
                 .candy(candy)
+                .ticket(ticket)
                 .build();
     }
 }

--- a/src/test/java/com/chatty/entity/user/UserTest.java
+++ b/src/test/java/com/chatty/entity/user/UserTest.java
@@ -1,5 +1,6 @@
 package com.chatty.entity.user;
 
+import com.chatty.exception.CustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,12 +19,58 @@ class UserTest {
 
         // then
         assertThat(user.getNickname()).isEqualTo("닉네임수정");
+    }
+    
+    @DisplayName("내가 보유하고있는 캔디의 수량이 필요한 캔디의 수량보다 작은지 확인한다.")
+    @Test
+    void isCandyQuantityLessThan() {
+        // given
+        User user = createUser(6);
 
+        // when
+        boolean result = user.isCandyQuantityLessThan(7);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("내가 보유하고있는 캔디의 수량을 차감한다.")
+    @Test
+    void deductCandyQuantity() {
+        // given
+        User user = createUser(7);
+        int candy = 7;
+
+        // when
+        user.deductCandyQuantity(candy);
+
+        // then
+        assertThat(user.getCandy()).isZero();
+    }
+
+    @DisplayName("내가 보유하고있는 캔디의 수량이 부족하면 예외가 발생한다.")
+    @Test
+    void deductCandyQuantity2() {
+        // given
+        User user = createUser(6);
+        int candy = 7;
+
+        // when // then
+        assertThatThrownBy(() -> user.deductCandyQuantity(candy))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("캔디의 개수가 부족합니다.");
     }
 
     private User createUser() {
         return User.builder()
                 .nickname("닉네임")
+                .build();
+    }
+
+    private User createUser(final int candy) {
+        return User.builder()
+                .nickname("닉네임")
+                .candy(candy)
                 .build();
     }
 }

--- a/src/test/java/com/chatty/repository/profileUnlock/ProfileUnlockRepositoryTest.java
+++ b/src/test/java/com/chatty/repository/profileUnlock/ProfileUnlockRepositoryTest.java
@@ -41,7 +41,7 @@ class ProfileUnlockRepositoryTest {
         ProfileUnlock profileUnlock = ProfileUnlock.builder()
                 .unlocker(user1)
                 .unlockedUser(user2)
-                .localDateTime(now)
+                .registeredDateTime(now)
                 .build();
 
         profileUnlockRepository.save(profileUnlock);

--- a/src/test/java/com/chatty/service/profileUnlock/ProfileUnlockServiceTest.java
+++ b/src/test/java/com/chatty/service/profileUnlock/ProfileUnlockServiceTest.java
@@ -1,0 +1,124 @@
+package com.chatty.service.profileUnlock;
+
+import com.chatty.constants.Authority;
+import com.chatty.dto.profileUnlock.request.ProfileUnlockRequest;
+import com.chatty.dto.profileUnlock.response.ProfileUnlockResponse;
+import com.chatty.entity.user.Gender;
+import com.chatty.entity.user.ProfileUnlock;
+import com.chatty.entity.user.User;
+import com.chatty.exception.CustomException;
+import com.chatty.repository.profileUnlock.ProfileUnlockRepository;
+import com.chatty.repository.user.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class ProfileUnlockServiceTest {
+
+    @Autowired
+    private ProfileUnlockService profileUnlockService;
+
+    @Autowired
+    private ProfileUnlockRepository profileUnlockRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        profileUnlockRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("캔디를 이용하여 프로필 잠금을 해제한다.")
+    @Test
+    void unlockProfile() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        User unlocker = createUser("박지성", "01012345678", 7);
+        User unlockedUser = createUser("강혜원", "01011112222", 7);
+        userRepository.saveAll(List.of(unlocker, unlockedUser));
+
+        ProfileUnlockRequest request = ProfileUnlockRequest.builder()
+                .unlockMethod("candy")
+                .build();
+
+        // when
+        ProfileUnlockResponse profileUnlockResponse = profileUnlockService.unlockProfile(unlockedUser.getId(), unlocker.getMobileNumber(), request, now);
+
+        // then
+        assertThat(profileUnlockResponse.getId()).isNotNull();
+        assertThat(profileUnlockResponse)
+                .extracting("unlockerId", "unlockedUserId", "registeredDateTime")
+                .containsExactlyInAnyOrder(unlocker.getId(), unlockedUser.getId(), now);
+    }
+
+    @DisplayName("캔디를 이용하여 프로필 잠금을 해제할 때, 보유한 캔디(7개미만)가 부족하면 예외가 발생한다.")
+    @Test
+    void unlockProfileWithNoCandy() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        User unlocker = createUser("박지성", "01012345678", 6);
+        User unlockedUser = createUser("강혜원", "01011112222", 7);
+        userRepository.saveAll(List.of(unlocker, unlockedUser));
+
+        ProfileUnlockRequest request = ProfileUnlockRequest.builder()
+                .unlockMethod("candy")
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> profileUnlockService.unlockProfile(unlockedUser.getId(), unlocker.getMobileNumber(), request, now))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("캔디의 개수가 부족합니다.");
+    }
+
+    @DisplayName("캔디를 이용하여 프로필 잠금을 해제할 때, 이미 잠금을 해제한 유저면 예외가 발생한다.")
+    @Test
+    void unlockProfileWithDuplicateUnlock() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        User unlocker = createUser("박지성", "01012345678", 6);
+        User unlockedUser = createUser("강혜원", "01011112222", 7);
+        userRepository.saveAll(List.of(unlocker, unlockedUser));
+
+        ProfileUnlock profileUnlock = ProfileUnlock.builder()
+                .registeredDateTime(now)
+                .unlocker(unlocker)
+                .unlockedUser(unlockedUser)
+                .build();
+        profileUnlockRepository.save(profileUnlock);
+
+        ProfileUnlockRequest request = ProfileUnlockRequest.builder()
+                .unlockMethod("candy")
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> profileUnlockService.unlockProfile(unlockedUser.getId(), unlocker.getMobileNumber(), request, now))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 프로필 잠금을 해제했습니다.");
+    }
+
+    private User createUser(final String nickname, final String mobileNumber, final int candy) {
+        return User.builder()
+                .mobileNumber(mobileNumber)
+                .deviceId("123456")
+                .authority(Authority.USER)
+                .birth(LocalDate.now())
+                .imageUrl("이미지")
+                .address("주소")
+                .gender(Gender.MALE)
+                .nickname(nickname)
+                .candy(candy)
+                .build();
+    }
+
+}

--- a/src/test/java/com/chatty/service/user/UserServiceTest.java
+++ b/src/test/java/com/chatty/service/user/UserServiceTest.java
@@ -10,6 +10,8 @@ import com.chatty.utils.S3Service;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -132,6 +134,29 @@ class UserServiceTest {
         // then
         assertThat(userResponse).isNotNull();
         assertThat(userResponse.getGender()).isEqualTo(Gender.MALE);
+    }
+
+    @DisplayName("성별을 수정할 때, 남성 - ticket 5장 / 여성 - ticket 11장을 받는다.")
+    @CsvSource({"MALE, 5", "FEMALE, 11"})
+    @ParameterizedTest
+    void updateGenderAndTicket(Gender gender, int ticket) {
+        // given
+        User user = createUser("닉네임", "01012345678");
+
+        userRepository.save(user);
+
+        UserGenderRequest request = UserGenderRequest.builder()
+                .gender(gender)
+                .build();
+
+        userService.updateGender(user.getMobileNumber(), request);
+
+        // when
+        User savedUser = userRepository.findUserByMobileNumber(user.getMobileNumber()).get();
+
+        // then
+        assertThat(savedUser.getGender()).isEqualTo(gender);
+        assertThat(savedUser.getTicket()).isEqualTo(ticket);
     }
 
     @DisplayName("생년월일을 수정한다.")


### PR DESCRIPTION
- 유저 엔티티 티켓, 캔디 컬럼 추가
  - 티켓, 캔디 부족 예외 메서드 작성
  - 티켓 캔디 사용 메서드 작성
- 상대방 프로필 잠금 해제 요청 메서드 리팩토링
  - 캔디 사용 or 티켓 사용 기능 추가
  - 잠금 중복 및 아이템 부족 예외 검증 로직 작성, 테스트 완료
- 상대방 프로필 조회 잠금 여부 체크(true, false) 테스트 완료