### PR TITLE
[Fix] 정규표현식 에러, 관심사 조회 권한 수정

### DIFF
--- a/src/main/java/com/chatty/config/SecurityConfig.java
+++ b/src/main/java/com/chatty/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import com.chatty.validator.TokenValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -39,6 +40,7 @@ public class SecurityConfig {
                         .requestMatchers("/reviews/home").hasRole("USER")
                         .requestMatchers("/reviews/**").authenticated()
                         .requestMatchers("/users/birth", "/users/gender").hasRole("ANONYMOUS")
+                        .requestMatchers(HttpMethod.GET, "/v1/interests").permitAll()
                         .requestMatchers("/users/**").hasAnyRole("USER", "ANONYMOUS")
                         .anyRequest().hasAnyRole("USER", "ADMIN")
                 )

--- a/src/main/java/com/chatty/controller/interest/InterestController.java
+++ b/src/main/java/com/chatty/controller/interest/InterestController.java
@@ -15,7 +15,7 @@ public class InterestController {
 
     private final InterestService interestService;
 
-    @GetMapping("/api/v1/interests")
+    @GetMapping("/v1/interests")
     public ApiResponse<List<InterestResponse>> getInterests() {
         return ApiResponse.ok(interestService.getInterests());
     }

--- a/src/main/java/com/chatty/controller/profile/ProfileUnlockController.java
+++ b/src/main/java/com/chatty/controller/profile/ProfileUnlockController.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users")
+@RequestMapping("/v1/users")
 @RestController
 public class ProfileUnlockController {
 

--- a/src/main/java/com/chatty/dto/user/request/UserNicknameRequest.java
+++ b/src/main/java/com/chatty/dto/user/request/UserNicknameRequest.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class UserNicknameRequest {
 
     @NotBlank(message = "닉네임은 필수로 입력해야 합니다.")
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
     private String nickname;
 
     @Builder

--- a/src/test/java/com/chatty/controller/interest/InterestControllerTest.java
+++ b/src/test/java/com/chatty/controller/interest/InterestControllerTest.java
@@ -51,7 +51,7 @@ class InterestControllerTest {
 
         // when // then
         mockMvc.perform(
-                        get("/api/v1/interests")
+                        get("/v1/interests")
                 )
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/com/chatty/controller/profile/ProfileUnlockControllerTest.java
+++ b/src/test/java/com/chatty/controller/profile/ProfileUnlockControllerTest.java
@@ -55,7 +55,7 @@ class ProfileUnlockControllerTest {
 
         // when // then
         mockMvc.perform(
-                        post("/api/v1/users/profile/{userId}", 2L).with(csrf())
+                        post("/v1/users/profile/{userId}", 2L).with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )
@@ -73,7 +73,7 @@ class ProfileUnlockControllerTest {
 
         // when // then
         mockMvc.perform(
-                        post("/api/v1/users/profile/{userId}", 2L).with(csrf())
+                        post("/v1/users/profile/{userId}", 2L).with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )

--- a/src/test/java/com/chatty/controller/user/UserControllerTest.java
+++ b/src/test/java/com/chatty/controller/user/UserControllerTest.java
@@ -341,30 +341,30 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.message").value("OK"));
     }
 
-    @DisplayName("회원가입을 진행할 때, 위치 정보는 필수값이다.")
-    @Test
-    void joinCompleteWithoutCoordinate() throws Exception {
-        // given
-        UserJoinRequest request = UserJoinRequest.builder()
-//                .coordinate(coordinate)
-                .nickname("닉네임")
-                .gender(Gender.MALE)
-                .mbti(Mbti.INFP)
-                .birth(LocalDate.now())
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        put("/users/update").with(csrf())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value("E000"))
-                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("좌표는 필수로 입력해야 합니다."));
-    }
+//    @DisplayName("회원가입을 진행할 때, 위치 정보는 필수값이다.")
+//    @Test
+//    void joinCompleteWithoutCoordinate() throws Exception {
+//        // given
+//        UserJoinRequest request = UserJoinRequest.builder()
+////                .coordinate(coordinate)
+//                .nickname("닉네임")
+//                .gender(Gender.MALE)
+//                .mbti(Mbti.INFP)
+//                .birth(LocalDate.now())
+//                .build();
+//
+//        // when // then
+//        mockMvc.perform(
+//                        put("/users/update").with(csrf())
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(objectMapper.writeValueAsString(request))
+//                )
+//                .andDo(print())
+//                .andExpect(status().isBadRequest())
+//                .andExpect(jsonPath("$.errorCode").value("E000"))
+//                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+//                .andExpect(jsonPath("$.message").value("좌표는 필수로 입력해야 합니다."));
+//    }
 
     @DisplayName("회원가입을 진행할 때, 닉네임은 필수값이다.")
     @Test

--- a/src/test/java/com/chatty/controller/user/UserControllerTest.java
+++ b/src/test/java/com/chatty/controller/user/UserControllerTest.java
@@ -86,7 +86,7 @@ class UserControllerTest {
     }
 
     @DisplayName("회원가입시 닉네임을 등록할 때, 닉네임의 길이는 2~10자로 입력해야 한다.")
-    @CsvSource({"닉", "닉네임11글자입니다요", "띄 어 쓰 기"})
+    @CsvSource({"닉", "닉네임11글자입니다요", "띄 어 쓰 기", "--__"})
     @ParameterizedTest
     void updateNicknameWithNicknameSize(final String nickname) throws Exception {
         // given


### PR DESCRIPTION
- 정규표현식에서 하이픈, 밑줄 허용되었던 거 차단
- 대문자 차단되었던 거 허용으로 수정
- 프로필 잠금 해제, 관심사 조회 api 네이밍 /api/v1/~~ -> /v1/~~ 로 수정
- 관심사 조회 permitAll로 수정