### PR TITLE
[Fix] findChatRoomBySenderOrReceiver -> findChatRoomByRoomIdAndSenderOrReceiver 메서드 버그 수정 

### DIFF
--- a/src/main/java/com/chatty/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/chatty/repository/chat/ChatRoomRepository.java
@@ -15,7 +15,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
     List<ChatRoom> findAllBySender(User sender);
     List<ChatRoom> findAllBySenderOrReceiverOrderByChatMessagesSendTimeDesc(User sender, User receiver);
 
-    Optional<ChatRoom> findChatRoomBySenderOrReceiver(User sender, User receiver);
+    Optional<ChatRoom> findChatRoomByRoomIdAndSenderOrReceiver(Long roomId, User sender, User receiver);
 
 //    @Query(value = "select c.* " +
 //            "from chat_room c " +

--- a/src/main/java/com/chatty/service/chat/ChatService.java
+++ b/src/main/java/com/chatty/service/chat/ChatService.java
@@ -41,7 +41,7 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
                 .orElseThrow(() -> new CustomException(Code.NOT_FOUND_CHAT_ROOM));
 
-        chatRoomRepository.findChatRoomBySenderOrReceiver(sender, sender)
+        chatRoomRepository.findChatRoomByRoomIdAndSenderOrReceiver(roomId, sender, sender)
                 .orElseThrow(() -> new CustomException(Code.NOT_IN_USER_ROOM));
 
         User receiver = chatRoom.getSender().equals(sender) ? chatRoom.getReceiver() : chatRoom.getSender();


### PR DESCRIPTION
- 이 메서드의 목적은 존재하는 채팅방에 유저가 속해있는지 확인하는 메서드다.
- 이전 메서드에서 발생한 문제는 1번 유저가 여러 채팅방에 속해있는 경우를 고려하지 못하여 Optional<ChatRoom>이 아닌 List로 반환되기 때문에 발생한 에러다.