### PR TITLE
[Fix] findChatRoomByRoomIdAndSenderOrReceiver Method 오류 수정

### DIFF
--- a/src/main/java/com/chatty/config/StompHandler.java
+++ b/src/main/java/com/chatty/config/StompHandler.java
@@ -32,7 +32,8 @@ public class StompHandler implements ChannelInterceptor {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         String accessToken = accessor.getFirstNativeHeader("Authorization");
         log.info("PreSendMethod");
-        log.info(accessor.getCommand().toString());
+        log.info("StompCommand = {}", accessor.getCommand().toString());
+        log.info("message = {}", message);
         // apic 이랑 websocket 테스트 툴이랑 다름.
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             log.info("CONNECT AND SEND 검증");

--- a/src/main/java/com/chatty/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/chatty/repository/chat/ChatRoomRepository.java
@@ -16,6 +16,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
     List<ChatRoom> findAllBySenderOrReceiverOrderByChatMessagesSendTimeDesc(User sender, User receiver);
 
     Optional<ChatRoom> findChatRoomByRoomIdAndSenderOrReceiver(Long roomId, User sender, User receiver);
+    boolean existsByRoomIdAndSenderOrReceiver(Long roomId, User sender, User receiver);
 
 //    @Query(value = "select c.* " +
 //            "from chat_room c " +

--- a/src/main/java/com/chatty/service/chat/ChatService.java
+++ b/src/main/java/com/chatty/service/chat/ChatService.java
@@ -41,8 +41,11 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
                 .orElseThrow(() -> new CustomException(Code.NOT_FOUND_CHAT_ROOM));
 
-        chatRoomRepository.findChatRoomByRoomIdAndSenderOrReceiver(roomId, sender, sender)
-                .orElseThrow(() -> new CustomException(Code.NOT_IN_USER_ROOM));
+        if (!chatRoomRepository.existsByRoomIdAndSenderOrReceiver(roomId, sender, sender)) {
+            throw new CustomException(Code.NOT_IN_USER_ROOM);
+        }
+//        chatRoomRepository.findChatRoomByRoomIdAndSenderOrReceiver(roomId, sender, sender)
+//                .orElseThrow(() -> new CustomException(Code.NOT_IN_USER_ROOM));
 
         User receiver = chatRoom.getSender().equals(sender) ? chatRoom.getReceiver() : chatRoom.getSender();
 


### PR DESCRIPTION
- sender가 보내려는 채팅방에 속해있는지 확인하는 과정에서, JPA Method 순서 문제 즉 And Or 중 And 우선 순위 때문에 잘못된 결과를 반환하였고 이러한 문제를 수정