### PR TITLE
[Refactor] 게시글 단건 조회 좋아요 개수 쿼리 최적화 적용

### DIFF
--- a/src/main/java/com/chatty/dto/post/response/PostResponse.java
+++ b/src/main/java/com/chatty/dto/post/response/PostResponse.java
@@ -55,7 +55,7 @@ public class PostResponse {
         this.isBookmark = isBookmark;
     }
 
-    public static PostResponse of(final Post post, final User user, final boolean isLike, final boolean isOwner, final boolean isBookmark) {
+    public static PostResponse of(final Post post, final User user, final boolean isLike, final boolean isOwner, final boolean isBookmark, final int likeCount) {
         return PostResponse.builder()
                 .postId(post.getId())
                 .content(post.getContent())
@@ -66,7 +66,7 @@ public class PostResponse {
                 .userId(post.getUser().getId())
                 .profileImage(post.getUser().getImageUrl())
                 .viewCount(post.getViewCount())
-                .likeCount(post.getPostLikes().size())
+                .likeCount(likeCount)
                 .commentCount(post.getComments().size())
                 .isLike(isLike)
                 .isOwner(isOwner)

--- a/src/main/java/com/chatty/repository/like/PostLikeRepository.java
+++ b/src/main/java/com/chatty/repository/like/PostLikeRepository.java
@@ -12,4 +12,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByPostAndUser(Post post, User user);
 
     Optional<PostLike> findByPostAndUser(Post post, User user);
+
+    int countByPost(Post post);
 }

--- a/src/main/java/com/chatty/service/post/PostService.java
+++ b/src/main/java/com/chatty/service/post/PostService.java
@@ -82,7 +82,9 @@ public class PostService {
         boolean isBookmark = bookmarkRepository.existsByPostAndUser(post, user);
         post.addViewCount();
 
-        return PostResponse.of(post, user, isLike, isOwner, isBookmark);
+        int likeCount = postLikeRepository.countByPost(post);
+
+        return PostResponse.of(post, user, isLike, isOwner, isBookmark, likeCount);
     }
 
     public List<PostListResponse> getPostList(final String mobileNumber) {


### PR DESCRIPTION
- .size()를 이용하면 DB에서 모든 post_like를 조회하여 list에 담기 때문에 속도가 매우 느리거나, OutOfMemory가 발생할 수 있음.
- count 쿼리를 따로 작성하여 개수를 넣어주는 방식으로 개선