### PR TITLE
[Refactor] 게시글 좋아요순 목록 조회 좋아요 개수, 좋아요 여부 쿼리 분리

### DIFF
--- a/src/main/java/com/chatty/dto/post/response/PostListResponse.java
+++ b/src/main/java/com/chatty/dto/post/response/PostListResponse.java
@@ -75,4 +75,25 @@ public class PostListResponse {
                         .anyMatch(bookmark -> bookmark.getUser().getId().equals(user.getId())))
                 .build();
     }
+
+    public static PostListResponse ofTest(final Post post, final User user, final int likeCount, final boolean isLike) {
+        return PostListResponse.builder()
+                .postId(post.getId())
+                .content(post.getContent())
+                .postImages(post.getPostImages().stream()
+                        .map(PostImage::getImage)
+                        .collect(Collectors.toList()))
+                .viewCount(post.getViewCount())
+                .createdAt(post.getCreatedAt())
+                .userId(post.getUser().getId())
+                .nickname(post.getUser().getNickname())
+                .imageUrl(post.getUser().getImageUrl())
+                .likeCount(likeCount)
+                .commentCount(post.getComments().size())
+                .isLike(isLike)
+                .isOwner(post.getUser().getId().equals(user.getId()))
+//                .isBookmark(post.getBookmarks().stream()
+//                        .anyMatch(bookmark -> bookmark.getUser().getId().equals(user.getId())))
+                .build();
+    }
 }

--- a/src/main/java/com/chatty/service/post/PostService.java
+++ b/src/main/java/com/chatty/service/post/PostService.java
@@ -132,8 +132,15 @@ public class PostService {
         List<Post> posts = postRepository.customFindByLikeCountLessThanOrderByLikeCountDescAndIdDesc(lastLikeCount, pageRequest);
 
         return posts.stream()
-                .map(post -> PostListResponse.of(post, user))
+                .map(post -> test(post, user))
                 .toList();
+    }
+
+    private PostListResponse test(Post post, User user) {
+        boolean isLike = postLikeRepository.existsByPostAndUser(post, user);
+        int likeCount = postLikeRepository.countByPost(post);
+
+        return PostListResponse.ofTest(post, user, likeCount, isLike);
     }
 
     public List<PostListResponse> getMyPostListPages(final Long lastPostId, final int size, final String mobileNumber) {


### PR DESCRIPTION
- .size()를 이용하면 DB에서 모든 post_like를 조회하여 list에 담기 때문에 속도가 매우 느리거나, OutOfMemory가 발생할 수 있음.
- count 쿼리를 따로 작성하여 개수를 넣어주는 방식으로 개선
- exists를 활용해 여부를 확인하는 방식으로 개선